### PR TITLE
Fixed train test split

### DIFF
--- a/homework/1-AE/hw-1.ipynb
+++ b/homework/1-AE/hw-1.ipynb
@@ -137,7 +137,7 @@
     "    labels.append(label)\n",
     "    \n",
     "# делаем так, чтобы сплит был сбалансированным по классам\n",
-    "indices_train, _, indices_test, _ = train_test_split(list(range(len(labels))), labels, test_size=0.1, stratify=labels)\n",
+    "indices_train, indices_test, _, _ = train_test_split(list(range(len(labels))), labels, test_size=0.1, stratify=labels)\n",
     "\n",
     "train_dataset = Subset(full_dataset, indices=indices_train)\n",
     "test_dataset = Subset(full_dataset, indices=indices_test)\n",


### PR DESCRIPTION
Исправлен порядок возвращаемых значений. Теперь индексы для трейна и теста не пересекаются и имеют нужный размер.

[Документация train_test_split](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html)